### PR TITLE
Allow manual loading of calendars

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -103,6 +103,11 @@ func New() *Parser {
 	return p
 }
 
+// Load calender from content
+func (p *Parser) Load(iCalContent string) {
+	p.parseICalContent(iCalContent, "")
+}
+
 //  returns the chan for calendar urls
 func (p *Parser) GetInputChan() chan string {
 	return p.inputChan

--- a/parse_test.go
+++ b/parse_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	ics "./" //"github.com/PuloV/ics-golang"
+	"github.com/PuloV/ics-golang"
 )
 
 func TestLoadCalendar(t *testing.T) {

--- a/parse_test.go
+++ b/parse_test.go
@@ -2,12 +2,40 @@ package ics_test
 
 import (
 	"fmt"
-	"github.com/PuloV/ics-golang"
+	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
 	"time"
+
+	ics "./" //"github.com/PuloV/ics-golang"
 )
+
+func TestLoadCalendar(t *testing.T) {
+	parser := ics.New()
+	calBytes, err := ioutil.ReadFile("testCalendars/2eventsCal.ics")
+	if err != nil {
+		t.Errorf("Failed to read calendar file ( %s )", err)
+	}
+
+	parser.Load(string(calBytes))
+
+	parseErrors, err := parser.GetErrors()
+	if err != nil {
+		t.Errorf("Failed to wait the parse of the calendars ( %s )", err)
+	}
+	for i, pErr := range parseErrors {
+		t.Errorf("Parsing Error №%d: %s", i, pErr)
+	}
+
+	calendars, errCal := parser.GetCalendars()
+	if errCal != nil {
+		t.Errorf("Failed to get calendars ( %s )", errCal)
+	}
+	if len(calendars) != 1 {
+		t.Errorf("Expected 1 calendar, found %d calendars", len(calendars))
+	}
+}
 
 func TestNewParser(t *testing.T) {
 	parser := ics.New()


### PR DESCRIPTION
This pull requests adds a new Load function that allows you to load calendars from a database, from sites protected with with mutual TLS authentication, inside an application running on Google AppEngine.

In many environments the http request handler needs to have a custom context or extra parameters this is why most golang packages work with an io.Reader. Chaching this version to support io.Reader is quite a big change. This pull requests makes the packages a lot more flexible and allows it to be used in more environments to begin with.