### PR TITLE
fix: allow line breaks in descriptions

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -446,9 +446,9 @@ func (p *Parser) parseEventStatus(eventData string) string {
 
 // parses the event description
 func (p *Parser) parseEventDescription(eventData string) string {
-	re, _ := regexp.Compile(`DESCRIPTION:.*?\n`)
+	re, _ := regexp.Compile(`DESCRIPTION:.*?\n(?:\s+.*?\n)*`)
 	result := re.FindString(eventData)
-	return trimField(result, "DESCRIPTION:")
+	return trimField(strings.Replace(result, "\r\n ", "", -1), "DESCRIPTION:")
 }
 
 // parses the event id provided form google


### PR DESCRIPTION
https://tools.ietf.org/html/rfc2445#section-4.8.1.5

   Example: The following is an example of the property with formatted
   line breaks in the property value:

     DESCRIPTION:Meeting to provide technical review for "Phoenix"
       design.\n Happy Face Conference Room. Phoenix design team
       MUST attend this meeting.\n RSVP to team leader.