### PR TITLE
Added Geo property to the parser and event.

### DIFF
--- a/event.go
+++ b/event.go
@@ -16,6 +16,7 @@ type Event struct {
 	status        string
 	description   string
 	location      string
+	geo           string
 	summary       string
 	rrule         string
 	class         string
@@ -228,6 +229,15 @@ func (e *Event) SetLocation(location string) *Event {
 
 func (e *Event) GetLocation() string {
 	return e.location
+}
+
+func (e *Event) SetGeo(geo string) *Event {
+	e.geo = geo
+	return e
+}
+
+func (e *Event) GetGeo() string {
+	return e.geo
 }
 
 func (e *Event) String() string {

--- a/event.go
+++ b/event.go
@@ -16,7 +16,7 @@ type Event struct {
 	status        string
 	description   string
 	location      string
-	geo           string
+	geo           *Geo
 	summary       string
 	rrule         string
 	class         string
@@ -231,12 +231,12 @@ func (e *Event) GetLocation() string {
 	return e.location
 }
 
-func (e *Event) SetGeo(geo string) *Event {
+func (e *Event) SetGeo(geo *Geo) *Event {
 	e.geo = geo
 	return e
 }
 
-func (e *Event) GetGeo() string {
+func (e *Event) GetGeo() *Geo {
 	return e.geo
 }
 

--- a/geo.go
+++ b/geo.go
@@ -1,0 +1,52 @@
+package ics
+
+import (
+	"strconv"
+)
+
+// Geo has latitude and longitude from the the GEO property of an event
+type Geo struct {
+	latStr string
+	lat    *float64
+
+	longStr string
+	long    *float64
+}
+
+// NewGeo creates a new Geo object
+func NewGeo(lat string, long string) *Geo {
+	return &Geo{
+		latStr:  lat,
+		longStr: long,
+	}
+}
+
+// Latitude returns the latitude value from Geo
+func (g *Geo) Latitude() (float64, error) {
+	if g.lat != nil {
+		return *g.lat, nil
+	}
+
+	latVal, err := strconv.ParseFloat(g.latStr, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	g.lat = &latVal
+	return latVal, nil
+}
+
+// Longitude returns the longitude value from Geo
+func (g *Geo) Longitude() (float64, error) {
+	if g.long != nil {
+		return *g.long, nil
+	}
+
+	longVal, err := strconv.ParseFloat(g.longStr, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	g.long = &longVal
+	return longVal, nil
+}

--- a/geo_test.go
+++ b/geo_test.go
@@ -1,0 +1,49 @@
+package ics
+
+import (
+	"testing"
+)
+
+func TestLongitudeReturnsError(t *testing.T) {
+	geo := NewGeo("1", "badLong")
+	_, err := geo.Longitude()
+
+	if err == nil {
+		t.Error("Expected error when getting Longitude but err was nil.")
+	}
+}
+
+func TestLongitudeReturnsValue(t *testing.T) {
+	geo := NewGeo("1", "123")
+	long, err := geo.Longitude()
+
+	if err != nil {
+		t.Error("Error when getting longitude.")
+	}
+
+	if long != 123 {
+		t.Errorf("Expected longitude value 123, but received %v", long)
+	}
+}
+
+func TestLatitudeReturnsError(t *testing.T) {
+	geo := NewGeo("badlat", "1")
+	_, err := geo.Latitude()
+
+	if err == nil {
+		t.Error("Expected error when getting Latitude but err was nil.")
+	}
+}
+
+func TestLatitudeReturnsValue(t *testing.T) {
+	geo := NewGeo("321", "1")
+	lat, err := geo.Latitude()
+
+	if err != nil {
+		t.Error("Error when getting latitude.")
+	}
+
+	if lat != 321 {
+		t.Errorf("Expected latitude value 321, but received %v", lat)
+	}
+}

--- a/parse.go
+++ b/parse.go
@@ -278,6 +278,7 @@ func (p *Parser) parseEvents(cal *Calendar, eventsData []string) {
 		event.SetLastModified(p.parseEventModified(eventData))
 		event.SetRRule(p.parseEventRRule(eventData))
 		event.SetLocation(p.parseEventLocation(eventData))
+		event.SetGeo(p.parseEventGeo(eventData))
 		event.SetStart(start)
 		event.SetEnd(end)
 		event.SetWholeDayEvent(wholeDay)
@@ -554,6 +555,13 @@ func (p *Parser) parseEventLocation(eventData string) string {
 	re, _ := regexp.Compile(`LOCATION:.*?\n`)
 	result := re.FindString(eventData)
 	return trimField(result, "LOCATION:")
+}
+
+// parses the event RRULE (the repeater)
+func (p *Parser) parseEventGeo(eventData string) string {
+	re, _ := regexp.Compile(`GEO:.*?\n`)
+	result := re.FindString(eventData)
+	return trimField(result, "GEO:")
 }
 
 // ======================== ATTENDEE PARSING ===================

--- a/parse.go
+++ b/parse.go
@@ -426,9 +426,7 @@ func (p *Parser) parseEvents(cal *Calendar, eventsData []string) {
 			}
 
 		}
-
 	}
-
 }
 
 // parses the event summary
@@ -550,18 +548,25 @@ func (p *Parser) parseEventRRule(eventData string) string {
 	return trimField(result, "RRULE:")
 }
 
-// parses the event RRULE (the repeater)
+// parses the event LOCATION
 func (p *Parser) parseEventLocation(eventData string) string {
 	re, _ := regexp.Compile(`LOCATION:.*?\n`)
 	result := re.FindString(eventData)
 	return trimField(result, "LOCATION:")
 }
 
-// parses the event RRULE (the repeater)
-func (p *Parser) parseEventGeo(eventData string) string {
+// parses the event GEO
+func (p *Parser) parseEventGeo(eventData string) *Geo {
 	re, _ := regexp.Compile(`GEO:.*?\n`)
 	result := re.FindString(eventData)
-	return trimField(result, "GEO:")
+
+	value := trimField(result, "GEO:")
+	values := strings.Split(value, ";")
+	if len(values) < 2 {
+		return nil
+	}
+
+	return NewGeo(values[0], values[1])
 }
 
 // ======================== ATTENDEE PARSING ===================

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,4 +1,4 @@
-package ics_test
+package ics
 
 import (
 	"fmt"
@@ -7,12 +7,10 @@ import (
 	"reflect"
 	"testing"
 	"time"
-
-	"github.com/PuloV/ics-golang"
 )
 
 func TestLoadCalendar(t *testing.T) {
-	parser := ics.New()
+	parser := New()
 	calBytes, err := ioutil.ReadFile("testCalendars/2eventsCal.ics")
 	if err != nil {
 		t.Errorf("Failed to read calendar file ( %s )", err)
@@ -38,7 +36,7 @@ func TestLoadCalendar(t *testing.T) {
 }
 
 func TestNewParser(t *testing.T) {
-	parser := ics.New()
+	parser := New()
 	rType := fmt.Sprintf("%v", reflect.TypeOf(parser))
 	if rType != "*ics.Parser" {
 		t.Errorf("Failed to create a Parser !")
@@ -46,7 +44,7 @@ func TestNewParser(t *testing.T) {
 }
 
 func TestNewParserChans(t *testing.T) {
-	parser := ics.New()
+	parser := New()
 	input := parser.GetInputChan()
 	output := parser.GetOutputChan()
 
@@ -63,7 +61,7 @@ func TestNewParserChans(t *testing.T) {
 }
 
 func TestParsing0Calendars(t *testing.T) {
-	parser := ics.New()
+	parser := New()
 	parser.Wait()
 
 	parseErrors, err := parser.GetErrors()
@@ -77,7 +75,7 @@ func TestParsing0Calendars(t *testing.T) {
 }
 
 func TestParsing1Calendars(t *testing.T) {
-	parser := ics.New()
+	parser := New()
 	input := parser.GetInputChan()
 	input <- "testCalendars/2eventsCal.ics"
 	parser.Wait()
@@ -104,7 +102,7 @@ func TestParsing1Calendars(t *testing.T) {
 }
 
 func TestParsing2Calendars(t *testing.T) {
-	parser := ics.New()
+	parser := New()
 	input := parser.GetInputChan()
 	input <- "testCalendars/2eventsCal.ics"
 	input <- "testCalendars/3eventsNoAttendee.ics"
@@ -132,7 +130,7 @@ func TestParsing2Calendars(t *testing.T) {
 }
 
 func TestParsingNotExistingCalendar(t *testing.T) {
-	parser := ics.New()
+	parser := New()
 	input := parser.GetInputChan()
 	input <- "testCalendars/notFound.ics"
 	parser.Wait()
@@ -149,7 +147,7 @@ func TestParsingNotExistingCalendar(t *testing.T) {
 }
 
 func TestParsingNotExistingAndExistingCalendars(t *testing.T) {
-	parser := ics.New()
+	parser := New()
 	input := parser.GetInputChan()
 	input <- "testCalendars/3eventsNoAttendee.ics"
 	input <- "testCalendars/notFound.ics"
@@ -176,7 +174,7 @@ func TestParsingNotExistingAndExistingCalendars(t *testing.T) {
 
 }
 func TestParsingWrongCalendarUrls(t *testing.T) {
-	parser := ics.New()
+	parser := New()
 	input := parser.GetInputChan()
 	input <- "http://localhost/goTestFails"
 	parser.Wait()
@@ -202,23 +200,23 @@ func TestParsingWrongCalendarUrls(t *testing.T) {
 }
 
 func TestCreatingTempDir(t *testing.T) {
-	ics.FilePath = "testingTempDir/"
-	parser := ics.New()
+	FilePath = "testingTempDir/"
+	parser := New()
 	input := parser.GetInputChan()
 	input <- "https://www.google.com/calendar/ical/yordanpulov%40gmail.com/private-81525ac0eb14cdc2e858c15e1b296a1c/basic.ics"
 	parser.Wait()
-	_, err := os.Stat(ics.FilePath)
+	_, err := os.Stat(FilePath)
 	if err != nil {
-		t.Errorf("Failed to create %s", ics.FilePath)
+		t.Errorf("Failed to create %s", FilePath)
 	}
 	// remove the new dir
-	os.Remove(ics.FilePath)
+	os.Remove(FilePath)
 	// return the var to default
-	ics.FilePath = "tmp/"
+	FilePath = "tmp/"
 }
 
 func TestCalendarInfo(t *testing.T) {
-	parser := ics.New()
+	parser := New()
 	input := parser.GetInputChan()
 	input <- "testCalendars/2eventsCal.ics"
 	parser.Wait()
@@ -267,12 +265,12 @@ func TestCalendarInfo(t *testing.T) {
 		t.Errorf("Expected %d events by date in calendar, got %d events", 2, len(eventsByDates))
 	}
 
-	geometryExamIcsFormat, errICS := time.Parse(ics.IcsFormat, "20140616T060000Z")
+	geometryExamIcsFormat, errICS := time.Parse(IcsFormat, "20140616T060000Z")
 	if err != nil {
 		t.Errorf("(ics time format) Unexpected error %s", errICS)
 	}
 
-	geometryExamYmdHis, errYMD := time.Parse(ics.YmdHis, "2014-06-16 06:00:00")
+	geometryExamYmdHis, errYMD := time.Parse(YmdHis, "2014-06-16 06:00:00")
 	if err != nil {
 		t.Errorf("(YmdHis time format) Unexpected error %s", errYMD)
 	}
@@ -295,7 +293,7 @@ func TestCalendarInfo(t *testing.T) {
 }
 
 func TestCalendarEvents(t *testing.T) {
-	parser := ics.New()
+	parser := New()
 	input := parser.GetInputChan()
 	input <- "testCalendars/2eventsCal.ics"
 	parser.Wait()
@@ -327,11 +325,12 @@ func TestCalendarEvents(t *testing.T) {
 	}
 
 	//  event must have
-	start, _ := time.Parse(ics.IcsFormat, "20140714T100000Z")
-	end, _ := time.Parse(ics.IcsFormat, "20140714T110000Z")
-	created, _ := time.Parse(ics.IcsFormat, "20140515T075711Z")
-	modified, _ := time.Parse(ics.IcsFormat, "20141125T074253Z")
+	start, _ := time.Parse(IcsFormat, "20140714T100000Z")
+	end, _ := time.Parse(IcsFormat, "20140714T110000Z")
+	created, _ := time.Parse(IcsFormat, "20140515T075711Z")
+	modified, _ := time.Parse(IcsFormat, "20141125T074253Z")
 	location := "In The Office"
+	geo := "39.620511;-75.852557"
 	desc := "1. Report on previous weekly tasks. \\n2. Plan of the present weekly tasks."
 	seq := 1
 	status := "CONFIRMED"
@@ -339,7 +338,7 @@ func TestCalendarEvents(t *testing.T) {
 	rrule := ""
 	attendeesCount := 3
 
-	org := new(ics.Attendee)
+	org := new(Attendee)
 	org.SetName("r.chupetlovska@gmail.com")
 	org.SetEmail("r.chupetlovska@gmail.com")
 
@@ -395,7 +394,7 @@ func TestCalendarEvents(t *testing.T) {
 	// SECOND EVENT WITHOUT ATTENDEES AND ORGANIZER
 	eventNoAttendees, errNoAttendees := calendar.GetEventByImportedID("mhhesb7si5968njvthgbiub7nk@google.com")
 	attendeesCount = 0
-	org = new(ics.Attendee)
+	org = new(Attendee)
 
 	if errNoAttendees != nil {
 		t.Errorf("Failed to get event by id with error %s", errNoAttendees)
@@ -411,7 +410,7 @@ func TestCalendarEvents(t *testing.T) {
 }
 
 func TestCalendarEventAttendees(t *testing.T) {
-	parser := ics.New()
+	parser := New()
 	input := parser.GetInputChan()
 	input <- "testCalendars/2eventsCal.ics"
 	parser.Wait()
@@ -499,7 +498,7 @@ func TestCalendarEventAttendees(t *testing.T) {
 }
 
 func TestCalendarMultidayEvent(t *testing.T) {
-	parser := ics.New()
+	parser := New()
 	input := parser.GetInputChan()
 	input <- "testCalendars/multiday.ics"
 	parser.Wait()

--- a/parse_test.go
+++ b/parse_test.go
@@ -330,7 +330,7 @@ func TestCalendarEvents(t *testing.T) {
 	created, _ := time.Parse(IcsFormat, "20140515T075711Z")
 	modified, _ := time.Parse(IcsFormat, "20141125T074253Z")
 	location := "In The Office"
-	geo := "39.620511;-75.852557"
+	geo := NewGeo("39.620511", "-75.852557")
 	desc := "1. Report on previous weekly tasks. \\n2. Plan of the present weekly tasks."
 	seq := 1
 	status := "CONFIRMED"
@@ -360,6 +360,14 @@ func TestCalendarEvents(t *testing.T) {
 
 	if event.GetLocation() != location {
 		t.Errorf("Expected location %s, found %s", location, event.GetLocation())
+	}
+
+	if event.GetGeo().latStr != geo.latStr {
+		t.Errorf("Expected geo %s, found %s", geo.latStr, event.GetGeo().latStr)
+	}
+
+	if event.GetGeo().longStr != geo.longStr {
+		t.Errorf("Expected geo %s, found %s", geo.longStr, event.GetGeo().longStr)
 	}
 
 	if event.GetDescription() != desc {

--- a/testCalendars/2eventsCal.ics
+++ b/testCalendars/2eventsCal.ics
@@ -41,6 +41,7 @@ CREATED:20140515T075711Z
 DESCRIPTION:1. Report on previous weekly tasks. \n2. Plan of the present weekly tasks.
 LAST-MODIFIED:20141125T074253Z
 LOCATION:In The Office
+GEO:39.620511;-75.852557
 SEQUENCE:1
 STATUS:CONFIRMED
 SUMMARY:General Operative Meeting


### PR DESCRIPTION
There's an ICS file I'd like to parse with your library, but one of the properties (geo) wasn't yet supported, so this PR is to add support for GEO. Here's the ICS file I am parsing: https://www.strongmancorporation.com/events/?ical=1&tribe_display=month.

Also, I needed to change the parser_test.go package and imports so that the tests weren't broken because I was using a fork. the reference to `github.com/PuloV/ics-golang` didn't work because I was running `github.com/quakkels/ics-golang`. The fix was just to remove the import altogether and place the tests in the same package as the code being tested.