### PR TITLE
Ical2org

### DIFF
--- a/event.go
+++ b/event.go
@@ -11,8 +11,10 @@ type Event struct {
 	end           time.Time
 	created       time.Time
 	modified      time.Time
+	stamp         time.Time
 	alarmTime     time.Duration
 	importedId    string
+	DTZID         []string
 	status        string
 	description   string
 	location      string
@@ -238,6 +240,24 @@ func (e *Event) SetGeo(geo *Geo) *Event {
 
 func (e *Event) GetGeo() *Geo {
 	return e.geo
+}
+
+func (e *Event) SetDTZID(icalZone []string) *Event {
+	e.DTZID = icalZone
+	return e
+}
+
+func (e *Event) GetDTZID() []string {
+	return e.DTZID
+}
+
+func (e *Event) SetDTStamp(stamp time.Time) *Event {
+	e.stamp = stamp
+	return e
+}
+
+func (e *Event) GetDTStamp() time.Time {
+	return e.stamp
 }
 
 func (e *Event) String() string {

--- a/parse.go
+++ b/parse.go
@@ -431,9 +431,9 @@ func (p *Parser) parseEvents(cal *Calendar, eventsData []string) {
 
 // parses the event summary
 func (p *Parser) parseEventSummary(eventData string) string {
-	re, _ := regexp.Compile(`SUMMARY:.*?\n(?:\s+.*?\n)*`)
+	re, _ := regexp.Compile(`SUMMARY(?:;.*?|):.*?\n(?:\s+.*?\n)*`)  // This will accept parameters and additional lines
 	result := re.FindString(eventData)
-	return trimField(strings.Replace(result, "\r\n ", "", -1), "SUMMARY:")
+	return trimField(strings.Replace(result, "\r\n ", "", -1), "SUMMARY.*?:")  // This concatenates additional lines and discards all parameters
 }
 
 // parses the event status
@@ -445,47 +445,47 @@ func (p *Parser) parseEventStatus(eventData string) string {
 
 // parses the event description
 func (p *Parser) parseEventDescription(eventData string) string {
-	re, _ := regexp.Compile(`DESCRIPTION:.*?\n(?:\s+.*?\n)*`)
+	re, _ := regexp.Compile(`DESCRIPTION(?:;.*?|):.*?\n(?:\s+.*?\n)*`)  // This will accept parameters and additional lines
 	result := re.FindString(eventData)
-	return trimField(strings.Replace(result, "\r\n ", "", -1), "DESCRIPTION:")
+	return trimField(strings.Replace(result, "\r\n ", "", -1), "DESCRIPTION.*?:")  // This concatenates additional lines and discards all parameters
 }
 
 // parses the event id provided form google
 func (p *Parser) parseEventId(eventData string) string {
-	re, _ := regexp.Compile(`UID:.*?\n`)
+	re, _ := regexp.Compile(`UID;?.*?:.*?\n`)  // This will accept parameters
 	result := re.FindString(eventData)
-	return trimField(result, "UID:")
+	return trimField(result, "UID.*?:")  // This will discard all parameters
 }
 
 // parses the event class
 func (p *Parser) parseEventClass(eventData string) string {
-	re, _ := regexp.Compile(`CLASS:.*?\n`)
+	re, _ := regexp.Compile(`CLASS;?.*?:.*?\n`) // This will accept parameters
 	result := re.FindString(eventData)
-	return trimField(result, "CLASS:")
+	return trimField(result, "CLASS.*?:")  // This will discard all parameters
 }
 
 // parses the event sequence
 func (p *Parser) parseEventSequence(eventData string) int {
-	re, _ := regexp.Compile(`SEQUENCE:.*?\n`)
+	re, _ := regexp.Compile(`SEQUENCE;?.*?:.*?\n`) // This will accept parameters
 	result := re.FindString(eventData)
-	sq, _ := strconv.Atoi(trimField(result, "SEQUENCE:"))
+	sq, _ := strconv.Atoi(trimField(result, "SEQUENCE.*?:"))  // This will discard all parameters
 	return sq
 }
 
 // parses the event created time
 func (p *Parser) parseEventCreated(eventData string) time.Time {
-	re, _ := regexp.Compile(`CREATED:.*?\n`)
+	re, _ := regexp.Compile(`CREATED;?.*?:.*?\n`)  // This will accept parameters
 	result := re.FindString(eventData)
-	created := trimField(result, "CREATED:")
+	created := trimField(result, "CREATED.*?:")  // This will discard all parameters
 	t, _ := time.Parse(IcsFormat, created)
 	return t
 }
 
 // parses the event modified time
 func (p *Parser) parseEventModified(eventData string) time.Time {
-	re, _ := regexp.Compile(`LAST-MODIFIED:.*?\n`)
+	re, _ := regexp.Compile(`LAST-MODIFIED;?.*?:.*?\n`)  // This will accept parameters
 	result := re.FindString(eventData)
-	modified := trimField(result, "LAST-MODIFIED:")
+	modified := trimField(result, "LAST-MODIFIED.*?:")  // This will discard all parameters
 	t, _ := time.Parse(IcsFormat, modified)
 	return t
 }
@@ -543,24 +543,24 @@ func (p *Parser) parseEventEnd(eventData string) time.Time {
 
 // parses the event RRULE (the repeater)
 func (p *Parser) parseEventRRule(eventData string) string {
-	re, _ := regexp.Compile(`RRULE:.*?\n`)
+	re, _ := regexp.Compile(`RRULE;?.*?:.*?\n`)  // This will accept parameters
 	result := re.FindString(eventData)
-	return trimField(result, "RRULE:")
+	return trimField(result, "RRULE.*?:")  // This will discard all parameters
 }
 
 // parses the event LOCATION
 func (p *Parser) parseEventLocation(eventData string) string {
-	re, _ := regexp.Compile(`LOCATION:.*?\n`)
+	re, _ := regexp.Compile(`LOCATION(?:;.*?|):.*?\n(?:\s+.*?\n)*`) // This will accept parameters and additional lines
 	result := re.FindString(eventData)
-	return trimField(result, "LOCATION:")
+	return trimField(strings.Replace(result, "\r\n ", "", -1), "LOCATION.*?:") // This concatenates additional lines and discards all parameters
 }
 
 // parses the event GEO
 func (p *Parser) parseEventGeo(eventData string) *Geo {
-	re, _ := regexp.Compile(`GEO:.*?\n`)
+	re, _ := regexp.Compile(`GEO;?.*?:.*?\n`)  // This will accept parameters
 	result := re.FindString(eventData)
 
-	value := trimField(result, "GEO:")
+	value := trimField(result, "GEO.*?:")  // This will discard all parameters
 	values := strings.Split(value, ";")
 	if len(values) < 2 {
 		return nil

--- a/parse.go
+++ b/parse.go
@@ -431,9 +431,9 @@ func (p *Parser) parseEvents(cal *Calendar, eventsData []string) {
 
 // parses the event summary
 func (p *Parser) parseEventSummary(eventData string) string {
-	re, _ := regexp.Compile(`SUMMARY:.*?\n`)
+	re, _ := regexp.Compile(`SUMMARY:.*?\n(?:\s+.*?\n)*`)
 	result := re.FindString(eventData)
-	return trimField(result, "SUMMARY:")
+	return trimField(strings.Replace(result, "\r\n ", "", -1), "SUMMARY:")
 }
 
 // parses the event status

--- a/utils.go
+++ b/utils.go
@@ -120,7 +120,7 @@ func parseDayNameToIcsName(day string) string {
 		dow = "FR"
 		break
 	case "Sat":
-		dow = "ST"
+		dow = "SA"
 		break
 	case "Sun":
 		dow = "SU"


### PR DESCRIPTION
These changes are to support a conversion of ical into org-mode entries.

1) adds DTSTAMP, TZID, and a few other attributes to the returned event.
2) Corrects a code
3) Allows for presence of optional and future parameters, and ignores them
4) Adds support for continuation lines for Summary and Location