### PR TITLE
Manage language suffixed summaries in accordance with RFC 5545 3.2.10

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -431,9 +431,9 @@ func (p *Parser) parseEvents(cal *Calendar, eventsData []string) {
 
 // parses the event summary
 func (p *Parser) parseEventSummary(eventData string) string {
-	re, _ := regexp.Compile(`SUMMARY:.*?\n`)
+	re, _ := regexp.Compile(`SUMMARY(?:;LANGUAGE=[a-zA-Z\-]+)?.*?\n`)
 	result := re.FindString(eventData)
-	return trimField(result, "SUMMARY:")
+	return trimField(result, `SUMMARY(?:;LANGUAGE=[a-zA-Z\-]+)?:`)
 }
 
 // parses the event status


### PR DESCRIPTION
Adds support for summaries with language section in accordance with: https://tools.ietf.org/html/rfc5545#section-3.2.10

A good example here:
https://regex101.com/r/shpKVr/1/