### PR TITLE
Timefield parsing error

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -501,8 +501,8 @@ func (p *Parser) parseEventModified(eventData string) time.Time {
 
 // parses the event start time
 func (p *Parser) parseTimeField(fieldName string, eventData string) (time.Time, string) {
-	reWholeDay, _ := regexp.Compile(fmt.Sprintf(`%s;VALUE=DATE:.*?\n`, fieldName))
-	re, _ := regexp.Compile(fmt.Sprintf(`%s(;TZID=(.*?))?(;VALUE=DATE-TIME)?:(.*?)\n`, fieldName))
+	reWholeDay, _ := regexp.Compile(fmt.Sprintf(`%s;VALUE=DATE:.*?\r?\n`, fieldName))
+	re, _ := regexp.Compile(fmt.Sprintf(`%s(;TZID=(.*?))?(;VALUE=DATE-TIME)?:(.*?)\r?\n`, fieldName))
 	resultWholeDay := reWholeDay.FindString(eventData)
 	var t time.Time
 	var tzID string


### PR DESCRIPTION
I was working with a calendar where the lines were separated with a carriage return and a new line. 

I noticed the start, and end times where not parsed correctly and it seems that on [line](https://github.com/PuloV/ics-golang/blob/master/parse.go#L521), the carriage return character had not been removed.

This solution seems to fix it.